### PR TITLE
[fix]: ignore games with 0:00 minutes in season averages

### DIFF
--- a/app/queries/season_average_query.rb
+++ b/app/queries/season_average_query.rb
@@ -50,6 +50,7 @@ class SeasonAverageQuery
         AND min != '0'
         AND min != ''
         AND min != '00:00'
+        AND min != '0:00'
         AND min != '00'
         AND postseason = false
       GROUP BY players.public_id, season


### PR DESCRIPTION
In previous seasons it appears that games in which a player had zero minutes appear as `0:00`, which should be ignored for correct season average values.